### PR TITLE
Add classes and indirection to code

### DIFF
--- a/src/Converter/CentimetersConverter.java
+++ b/src/Converter/CentimetersConverter.java
@@ -1,0 +1,16 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package Converter;
+
+/**
+ *
+ * @author flescano
+ */
+public class CentimetersConverter extends Converter {
+    public CentimetersConverter() {
+        super.unit = 0.1;
+    }
+}

--- a/src/Converter/Converter.java
+++ b/src/Converter/Converter.java
@@ -1,0 +1,21 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package Converter;
+
+/**
+ *
+ * @author flescano
+ */
+public abstract class Converter {
+    protected Double unit;
+    public Double toMilimeters(Double value) {
+        return value/unit;
+    };
+    
+    public Double fromMilimeters(Double value) {
+        return value*unit;
+    }
+}

--- a/src/Converter/InchesConverter.java
+++ b/src/Converter/InchesConverter.java
@@ -1,0 +1,16 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package Converter;
+
+/**
+ *
+ * @author flescano
+ */
+public class InchesConverter extends Converter {
+    public InchesConverter() {
+        super.unit = 0.0393701;
+    }
+}

--- a/src/Converter/KilometersConverter.java
+++ b/src/Converter/KilometersConverter.java
@@ -1,0 +1,16 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package Converter;
+
+/**
+ *
+ * @author flescano
+ */
+public class KilometersConverter extends Converter {
+    public KilometersConverter() {
+        super.unit = 1e-6;
+    }
+}

--- a/src/Converter/MetersConverter.java
+++ b/src/Converter/MetersConverter.java
@@ -1,0 +1,16 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package Converter;
+
+/**
+ *
+ * @author flescano
+ */
+public class MetersConverter extends Converter {
+    public MetersConverter() {
+        super.unit = 0.001;
+    }
+}

--- a/src/Converter/MilesConverter.java
+++ b/src/Converter/MilesConverter.java
@@ -1,0 +1,16 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package Converter;
+
+/**
+ *
+ * @author flescano
+ */
+public class MilesConverter extends Converter {
+    public MilesConverter() {
+        super.unit = 6.21371e-7;
+    }
+}

--- a/src/Converter/MilimetersConverter.java
+++ b/src/Converter/MilimetersConverter.java
@@ -1,0 +1,16 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package Converter;
+
+/**
+ *
+ * @author flescano
+ */
+public class MilimetersConverter extends Converter {
+    public MilimetersConverter() {
+        super.unit = 1D;
+    }
+}

--- a/src/Main/Conversor.form
+++ b/src/Main/Conversor.form
@@ -72,7 +72,6 @@
         <Property name="text" type="java.lang.String" value="0.00"/>
       </Properties>
       <Events>
-        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="originFieldActionPerformed"/>
         <EventHandler event="keyReleased" listener="java.awt.event.KeyListener" parameters="java.awt.event.KeyEvent" handler="originFieldKeyReleased"/>
       </Events>
     </Component>
@@ -89,10 +88,6 @@
         <Property name="text" type="java.lang.String" value="0.00"/>
         <Property name="enabled" type="boolean" value="false"/>
       </Properties>
-      <Events>
-        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="finalFieldActionPerformed"/>
-        <EventHandler event="keyReleased" listener="java.awt.event.KeyListener" parameters="java.awt.event.KeyEvent" handler="finalFieldKeyReleased"/>
-      </Events>
     </Component>
     <Component class="javax.swing.JLabel" name="errorText">
       <Properties>

--- a/src/Main/Conversor.java
+++ b/src/Main/Conversor.java
@@ -1,10 +1,6 @@
 package Main;
 
-
-import Converter.PulToCentConverter;
-import Converter.CentToPulConverter;
 import javax.swing.JOptionPane;
-import Converter.ConverterInterface;
 
 /*
  * To change this license header, choose License Headers in Project Properties.
@@ -23,10 +19,10 @@ public class Conversor extends javax.swing.JFrame {
      */
     public Conversor() {
         initComponents();
-        setTitle("Mi conversor generico");
+        setTitle("Mi conversor de distancias");
         setLocationRelativeTo(null);
         
-        converter = new Converter();
+        converter = new ConverterController();
         
         for (String unit : converter.getUnits()) {
             jComboBoxOriginUnit.addItem(unit);
@@ -54,11 +50,6 @@ public class Conversor extends javax.swing.JFrame {
         setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
 
         originField.setText("0.00");
-        originField.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                originFieldActionPerformed(evt);
-            }
-        });
         originField.addKeyListener(new java.awt.event.KeyAdapter() {
             public void keyReleased(java.awt.event.KeyEvent evt) {
                 originFieldKeyReleased(evt);
@@ -74,16 +65,6 @@ public class Conversor extends javax.swing.JFrame {
 
         finalField.setText("0.00");
         finalField.setEnabled(false);
-        finalField.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                finalFieldActionPerformed(evt);
-            }
-        });
-        finalField.addKeyListener(new java.awt.event.KeyAdapter() {
-            public void keyReleased(java.awt.event.KeyEvent evt) {
-                finalFieldKeyReleased(evt);
-            }
-        });
 
         errorText.setForeground(new java.awt.Color(255, 0, 0));
 
@@ -149,10 +130,6 @@ public class Conversor extends javax.swing.JFrame {
         pack();
     }// </editor-fold>//GEN-END:initComponents
 
-    private void originFieldActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_originFieldActionPerformed
-        // TODO add your handling code here:
-    }//GEN-LAST:event_originFieldActionPerformed
-
     private void jButtonConvertirActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButtonConvertirActionPerformed
         errorText.setText("");
         Double input = 0D;
@@ -171,7 +148,6 @@ public class Conversor extends javax.swing.JFrame {
         }
     }//GEN-LAST:event_jButtonConvertirActionPerformed
 
-    
     private Double getDouble(javax.swing.JTextField field) {
         return Double.valueOf(field.getText());
     }
@@ -179,21 +155,13 @@ public class Conversor extends javax.swing.JFrame {
     private void originFieldKeyReleased(java.awt.event.KeyEvent evt) {//GEN-FIRST:event_originFieldKeyReleased
         this.convertirACent = false;
         this.cleanField(finalField);
+        // TODO: Check enter.
     }//GEN-LAST:event_originFieldKeyReleased
-
-    private void finalFieldKeyReleased(java.awt.event.KeyEvent evt) {//GEN-FIRST:event_finalFieldKeyReleased
-        this.convertirACent = true;
-        this.cleanField(originField);
-    }//GEN-LAST:event_finalFieldKeyReleased
 
     private void cleanField(javax.swing.JTextField field) {
         field.setText("");
     }
     
-    private void finalFieldActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_finalFieldActionPerformed
-        // TODO add your handling code here:
-    }//GEN-LAST:event_finalFieldActionPerformed
-
     private void jComboBoxOriginUnitActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jComboBoxOriginUnitActionPerformed
         // TODO add your handling code here:
     }//GEN-LAST:event_jComboBoxOriginUnitActionPerformed
@@ -256,5 +224,5 @@ public class Conversor extends javax.swing.JFrame {
 
     
     private Boolean convertirACent = false;
-    private Converter converter;
+    private ConverterController converter;
 }

--- a/src/Main/ConverterController.java
+++ b/src/Main/ConverterController.java
@@ -5,6 +5,11 @@
  */
 package Main;
 
+import Converter.InchesConverter;
+import Converter.KilometersConverter;
+import Converter.MetersConverter;
+import Converter.MilesConverter;
+import Converter.MilimetersConverter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -12,17 +17,17 @@ import java.util.Map;
  *
  * @author flescano
  */
-public class Converter {
-    public Converter () {
+public class ConverterController {
+    public ConverterController () {
         originUnit = MILIMETERS;
         finalUnit = MILIMETERS;
         
-        convertValues.put(MILIMETERS, 1D);
-        convertValues.put(METERS, 0.001);
-        convertValues.put(INCHES, 0.0393701);
-        convertValues.put(MILES, 6.21371e-7);
-        convertValues.put(KILOMETERS, 1e-6);
-        convertValues.put(CENTIMETERS, 0.1);
+        convertInstances.put(MILIMETERS, new MilimetersConverter());
+        convertInstances.put(METERS, new MetersConverter());
+        convertInstances.put(INCHES, new InchesConverter());
+        convertInstances.put(MILES, new MilesConverter());
+        convertInstances.put(KILOMETERS, new KilometersConverter());
+        convertInstances.put(CENTIMETERS, new MilimetersConverter());
     }
     
     public String[] getUnits() {
@@ -52,13 +57,12 @@ public class Converter {
     }
     
     private Double toMilimeters(Double value) {
-        return value/convertValues.get(originUnit);
+        return convertInstances.get(originUnit).toMilimeters(value);
     }
     
     private Double toFinalUnit(Double value) {
-        return value*convertValues.get(finalUnit);
+        return convertInstances.get(finalUnit).fromMilimeters(value);
     }
-    
     
     private static final String MILIMETERS = "Milimetros"; 
     private static final String METERS = "Metros";
@@ -67,7 +71,7 @@ public class Converter {
     private static final String KILOMETERS = "Kilometros"; 
     private static final String CENTIMETERS = "Centimetros";
     
-    private static Map<String, Double> convertValues = new HashMap<String, Double>();
+    private static Map<String, Converter.Converter> convertInstances = new HashMap<String, Converter.Converter>();
     
     private String originUnit;
     private String finalUnit;


### PR DESCRIPTION
Agregue una clase abstracta que implementa los métodos para convertir a milímetros y las clases  específicas para cada conversión donde lo único que se hace es setear el valor unitario para convertir esa unidad a o desde milímetros. 

La idea es mantener la simplicidad de solo llamar a un método y no depender de un if para hacer los cálculos, haciendo el pasaje a milímetros en el medio nos ahorramos lógica, ya que cada clase solo necesita saber pasar a milímetros. De otra forma necesitariamos una clase para cada conversion entre unidades, creciendo exponencialmente si siempre queremos mantener todas las unidades. 